### PR TITLE
Overflow safety

### DIFF
--- a/src/felt.rs
+++ b/src/felt.rs
@@ -9,8 +9,9 @@ impl<const MODULUS: u64> Add for Felt<MODULUS> {
     type Output = Felt<MODULUS>;
 
     fn add(self, other: Felt<MODULUS>) -> Felt<MODULUS> {
+        let safe_value: u128 = (self.value as u128 + other.value as u128) % MODULUS as u128;
         Felt {
-            value: (self.value + other.value) % MODULUS,
+            value: safe_value as u64, // This is safe to convert back to 64 as we before only used 64 for our Modulus!
         }
     }
 }
@@ -19,8 +20,9 @@ impl<const MODULUS: u64> Mul<u64> for Felt<MODULUS> {
     type Output = Felt<MODULUS>;
 
     fn mul(self, other: u64) -> Felt<MODULUS> {
+        let safe_value: u128 = (self.value as u128 * other as u128) % MODULUS as u128;
         Felt {
-            value: (self.value * other) % MODULUS,
+            value: safe_value as u64,
         }
     }
 }
@@ -37,8 +39,9 @@ impl<const MODULUS: u64> Mul for Felt<MODULUS> {
     type Output = Felt<MODULUS>;
 
     fn mul(self, other: Felt<MODULUS>) -> Felt<MODULUS> {
+        let safe_value: u128 = (self.value as u128 * other.value as u128) % MODULUS as u128;
         Felt {
-            value: (self.value * other.value) % MODULUS,
+            value: safe_value as u64,
         }
     }
 }
@@ -87,11 +90,33 @@ mod tests {
     }
 
     #[test]
+    fn test_overflow_add() {
+        let a = Felt17::new(std::u64::MAX);
+        let b = Felt17::new(1);
+        let c = a + b;
+        // https://www.wolframalpha.com/input?i=%2818446744073709551615+%2B+1%29+mod+17
+        let expected = Felt17::new(1);
+
+        assert_eq!(c, expected);
+    }
+
+    #[test]
     fn test_mul_scalar() {
         let a = Felt17::new(5);
         let b = 12;
         let c = a * b;
         let expected = Felt17::new(9);
+
+        assert_eq!(c, expected);
+    }
+
+    #[test] //
+    fn test_overflow_mul_scalar() {
+        let a = Felt17::new(18446744073709551614);
+        let b = 5;
+        let c = a * b;
+        // https://www.wolframalpha.com/input?i=%2818446744073709551614+*+5%29+mod+17
+        let expected = Felt17::new(12);
 
         assert_eq!(c, expected);
     }
@@ -106,12 +131,32 @@ mod tests {
         assert_eq!(c, d);
     }
 
+    #[test] //
+    fn test_overflow_mul_scalar_commutative() {
+        let a = Felt17::new(18446744073709551614);
+        let b = 5;
+        let c = b * a;
+        let d = a * b;
+
+        assert_eq!(c, d);
+    }
+
     #[test]
     fn test_mul() {
         let a = Felt17::new(2);
         let b = Felt17::new(12);
         let c = a * b;
         let expected = Felt17::new(7);
+
+        assert_eq!(c, expected);
+    }
+
+    #[test] //
+    fn test_overflow_mul() {
+        let a = Felt17::new(18446744073709551614);
+        let b = Felt17::new(5);
+        let c = a * b;
+        let expected = Felt17::new(12);
 
         assert_eq!(c, expected);
     }


### PR DESCRIPTION
I was not sure if i want to use u128::from(..) because i kind of want them only to  be shortly converted not permanently.
Correct me if i am wrong:)